### PR TITLE
upgrade ruby to 2.6.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.6.5-node-browsers
+FROM circleci/ruby:2.6.8-node-browsers
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
Rubyのバージョンを2.6系最新の2.6.8に更新します。

Docker Hubにlatestとは異なるtagでimageを生成したいため、マージは行わないでください。