### PR TITLE
旧イメージのサポート切れのためベースイメージをcimgに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.6.9-node-browsers
+FROM cimg/ruby:2.6.9-browsers
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
circleci/ruby:2.6.9-node-browsers では旧イメージ `circleci/` を使用しているが、こちらのサポートは2021年で終了する（配信はdocker hubで継続）。
以降のrubyのバージョンでは提供されなくなるため、現行イメージである `cimg/` に変更する。