### PR TITLE
Ruby 2.6.5 + node 12.22.9 のイメージを作る

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN curl -sSL https://git.io/misspell | bash \
     && sudo ln -s /home/circleci/bin/misspell /usr/local/bin/misspell
 
 # install node newer version for eslint
-RUN wget https://nodejs.org/download/release/v12.18.2/node-v12.18.2-linux-x64.tar.xz \
-    && tar Jxfv node-v12.18.2-linux-x64.tar.xz \
-    && sudo cp node-v12.18.2-linux-x64/bin/node /usr/local/bin/ \
-    && rm -rf node-v12.18.2-linux-x64 node-v12.18.2-linux-x64.tar.xz
+RUN wget https://nodejs.org/download/release/v12.22.9/node-v12.22.9-linux-x64.tar.xz \
+    && tar Jxfv node-v12.22.9-linux-x64.tar.xz \
+    && sudo cp node-v12.22.9-linux-x64/bin/node /usr/local/bin/ \
+    && rm -rf node-v12.22.9-linux-x64 node-v12.22.9-linux-x64.tar.xz
 
 RUN wget https://noto-website-2.storage.googleapis.com/pkgs/NotoSansCJKjp-hinted.zip \
     && mkdir -p ~/.fonts/noto \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/ruby:2.6.9-node-browsers
+FROM circleci/ruby:2.6.5-node-browsers
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
Ruby が 2.6.9 にアップグレードされるまでの繋ぎ