### PR TITLE
upgrade ruby to 3.0.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:2.7.5
+FROM cimg/ruby:3.0.5
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
- https://github.com/icare-jp/www/pull/11143

ruby 3.0.5 のバージョンアップのために必要であったため、アップしました。