### PR TITLE
Node.js の 16.20.2 へのアップデート と Ruby のメモリアロケータを jemalloc へ変更（自動）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ RUN sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DCC9EFBF77E115
 ADD chromium.pref /etc/apt/preferences.d
 
 # install node newer version for eslint
-RUN wget https://nodejs.org/download/release/v14.20.1/node-v14.20.1-linux-x64.tar.xz \
-    && tar Jxfv node-v14.20.1-linux-x64.tar.xz \
-    && sudo cp node-v14.20.1-linux-x64/bin/node /usr/local/bin/ \
-    && rm -rf node-v14.20.1-linux-x64 node-v14.20.1-linux-x64.tar.xz
+RUN wget https://nodejs.org/download/release/v16.20.2/node-v16.20.2-linux-x64.tar.xz \
+    && tar Jxfv node-v16.20.2-linux-x64.tar.xz \
+    && sudo cp node-v16.20.2-linux-x64/bin/node /usr/local/bin/ \
+    && rm -rf node-v16.20.2-linux-x64 node-v16.20.2-linux-x64.tar.xz
 
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
# 概要
- Node.jsのバージョンを16.20.2へアップデート
- Rubyのメモリアロケータをjemalloc変更（2023年9月4日からデフォルトでjemallocへ変更となったので作り直すだけでjemallocが使われるようになる）
　- https://github.com/CircleCI-Public/cimg-ruby/pull/139