### PR TITLE
Upgrade Ruby to 3.1.4 with node16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@
 # https://github.com/CircleCI-Public/cimg-ruby/blob/46fb83d41876206604891a6367f98674c284725a/Dockerfile.template
 FROM cimg/base:2023.07
 
-ENV RUBY_VERSION=3.0.5 \
-	RUBY_MAJOR=3.0
+ENV RUBY_VERSION=3.1.4 \
+	RUBY_MAJOR=3.1
 
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 		autoconf \
@@ -116,10 +116,10 @@ RUN sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DCC9EFBF77E115
 ADD chromium.pref /etc/apt/preferences.d
 
 # install node newer version for eslint
-RUN wget https://nodejs.org/download/release/v18.19.0/node-v18.19.0-linux-x64.tar.xz \
-    && tar Jxfv node-v18.19.0-linux-x64.tar.xz \
-    && sudo cp node-v18.19.0-linux-x64/bin/node /usr/local/bin/ \
-    && rm -rf node-v18.19.0-linux-x64 node-v18.19.0-linux-x64.tar.xz
+RUN wget https://nodejs.org/download/release/v16.20.2/node-v16.20.2-linux-x64.tar.xz \
+    && tar Jxfv node-v16.20.2-linux-x64.tar.xz \
+    && sudo cp node-v16.20.2-linux-x64/bin/node /usr/local/bin/ \
+    && rm -rf node-v16.20.2-linux-x64 node-v16.20.2-linux-x64.tar.xz
 
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
Ruby3.1.4への更新を行います。
masterブランチのNodeが18に更新されてしまっているため、Node16バージョンでも作成し、CIでNode16/18のDockerイメージの使い分けを行います。

masterブランチはNode18のままにしておくので、こちらはマージしません。
Dockerhubのイメージ作成のためのみにこのPRを使用し、マージせずにクローズします。