### PR TITLE
Upgrade Ruby to 3.1.4 with Node18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.0.5
+FROM cimg/ruby:3.1.4
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
Ruby3.1.4へアップグレードします