### PR TITLE
Upgrade Ruby to 3.2.2 with Node16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.1.4
+FROM cimg/ruby:3.2.2
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
Ruby3.2.2への更新を行います。
masterブランチのNodeが18に更新されてしまっているため、Node16バージョンでも作成し、CIでNode16/18のDockerイメージの使い分けを行います。

masterブランチはNode18のままにしておくので、こちらはマージしません。
Dockerhubのイメージ作成のためのみにこのPRを使用し、マージせずにクローズします。