### PR TITLE
Upgrade Ruby to 3.3.0 with Node16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.2.2
+FROM cimg/ruby:3.3.0
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
Ruby3.3.0への更新を行います。
masterブランチのNodeが18に更新されてしまっているため、Node16バージョンでも作成し、CIでNode16/18のDockerイメージの使い分けを行います。
差分にNode関連の修正がありませんが、ベースブランチがNode16であるためです。

masterブランチはNode18のままにしておくので、こちらはマージしません。
Dockerhubのイメージ作成のためのみにこのPRを使用し、マージせずにクローズします。