### PR TITLE
Upgrade Ruby to 3.2.2 with Node18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.0.5
+FROM cimg/ruby:3.2.2
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
Ruby3.2.2へアップグレードします。