### PR TITLE
Upgrade Ruby to 3.3.0 with Node18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cimg/ruby:3.0.5
+FROM cimg/ruby:3.3.0
 
 LABEL maintainer="dev@icare.jpn.com"
 


### PR DESCRIPTION
Ruby 3.3.0へアップグレードします。masterブランチのNodeバージョンが18であるため、masterから作成しているこちらもNode18バージョンのイメージ作成に使用します。
