### PR TITLE
[WIP]CVE-2024-27282 rubyメモリアドレス読み取りの脆弱性に対応するため ruby 3.2.4へアップグレード（Node16）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,6 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/instal
     && source $HOME/.nvm/nvm.sh \
     && nvm install ${NODE_VERSION} \
     && node -v \
-    && npm -v
+    && npm -v \
+    && npm install -g yarn@1 \
+    && yarn -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,3 +48,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/instal
     && npm -v \
     && npm install -g yarn@1 \
     && yarn -v
+
+# remove lines 5 & 6
+# CircleCIで shell session を interactive にする必要があるため
+RUN sed -i '5,6d' /root/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM cimg/ruby:3.2.3
+FROM cimg/ruby:3.2.4
 
-ENV NODE_VERSION=18.20.2
+ENV NODE_VERSION=16.20.2
 ENV NVM_VERSION=0.39.7
 ENV TZ='Asia/Tokyo'
 


### PR DESCRIPTION
# 概要
Nodeのバージョンを18、16で使い分ける必要があるためPRだけ作成（masterブランチへはマージしない）

ruby 3.2.3 で正規表現（Regex）検索に任意のメモリアドレスを読み取られる脆弱性が発見されたため ruby 3.2.4 へアップグレード
https://www.ruby-lang.org/en/news/2024/04/23/arbitrary-memory-address-read-regexp-cve-2024-27282/