### PR TITLE
busterからbullseyeに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ RUN <<EOF
   echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list
   echo "deb http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
   echo "deb http://deb.debian.org/debian-security bullseye-security main" >> /etc/apt/sources.list
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0E98404D386FA1D9
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6ED0E7B82643E131
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 605C66F00D6C9793
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 54404762BBB6E853
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys BDE6D2B9216EC7A8
 EOF
 
 ADD chromium.pref /etc/apt/preferences.d

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,9 @@ EOF
 
 # prepare to debian version of chromium
 RUN <<EOF
-  echo "deb http://deb.debian.org/debian buster main" >> /etc/apt/sources.list
-  echo "deb http://deb.debian.org/debian buster-updates main" >> /etc/apt/sources.list
-  echo "deb http://deb.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DCC9EFBF77E11517
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 648ACFD622F3D138
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AA8E81B4331F7F50
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 112695A0E562B32A
+  echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list
+  echo "deb http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
+  echo "deb http://deb.debian.org/debian-security bullseye-security main" >> /etc/apt/sources.list
 EOF
 
 ADD chromium.pref /etc/apt/preferences.d


### PR DESCRIPTION
# 概要

- Debian 10 ( buster ) がEOLに伴いレポジトリへのアクセスが不可になった
- Debian 11 ( bullseye ) に変更した

# 動作確認

てもとのDocker Desktopでビルドすることを確認済

```
ruby-node-browsers-with-misspell % docker build -t test-ruby-node-browsers .

 => exporting to image                                                                                                                                                                                                                        0.2s
 => => exporting layers                                                                                                                                                                                                                       0.2s
 => => naming to docker.io/library/test-ruby-node-browsers                                                                                                                                                                                    0.0s 
                                                                                                                                                                                                                                                   
What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview 
```